### PR TITLE
Disable WebView file access in SecondActivity

### DIFF
--- a/app/src/main/java/com/nltechno/dolidroidpro/SecondActivity.java
+++ b/app/src/main/java/com/nltechno/dolidroidpro/SecondActivity.java
@@ -347,7 +347,13 @@ public class SecondActivity extends Activity {
         this.savedUserAgent = myWebView.getSettings().getUserAgentString() + " - " + getString(R.string.dolidroidUserAgent);
 
         myWebView.getSettings().setAllowContentAccess(true);
-        myWebView.getSettings().setAllowFileAccess(true);
+        // The WebView only ever loads the user's configured Dolibarr
+        // server URL (urlToGo, an http/https URL). It does not need
+        // file:// access, and the HTMLOUT JS bridge attached below
+        // would be reachable from any file:// document if a stray load
+        // ever landed in this WebView. file:///android_asset/ remains
+        // reachable regardless of the flag.
+        myWebView.getSettings().setAllowFileAccess(false);
         //myWebView.getSettings().setAllowFileAccessFromFileURLs(true);
         //myWebView.getSettings().setAllowUniversalAccessFromFileURLs(true);
         myWebView.getSettings().setDomStorageEnabled(true);


### PR DESCRIPTION
Closes #19.

`SecondActivity` builds the main Dolibarr WebView with `setAllowFileAccess(true)` and attaches the `HTMLOUT` JS bridge:

```java
myWebView.getSettings().setAllowFileAccess(true);
//myWebView.getSettings().setAllowFileAccessFromFileURLs(true);
//myWebView.getSettings().setAllowUniversalAccessFromFileURLs(true);
...
myWebView.addJavascriptInterface(myJavaScriptInterface, "HTMLOUT");
...
myWebView.loadUrl(urlToGo);
```

`urlToGo` is the user's configured Dolibarr server URL (http or https from the saved preferences). The WebView never legitimately loads a `file://` URL, so the flag only widens what a stray file-URL load could reach through the `HTMLOUT` bridge.

### Change

Flip `setAllowFileAccess(true)` to `setAllowFileAccess(false)`. The `file:///android_asset/*` scheme remains available on every supported Android version regardless of this flag, so no asset path is affected. The two commented-out `FromFileURLs(true)` lines are left in place as a record of the existing decision not to re-enable them.

### Out of scope

The `onReceivedSslError` handler in this file uses an interactive `SslAlertDialog` for the first error and only auto-proceeds when the user has previously accepted the same error in this session (`sslErrorWasAccepted`). That is interactive consent, so it is intentionally not part of this PR.